### PR TITLE
Add MCP server documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A collection of shell scripts that add semantic search capabilities to Apple Not
 - 🔄 **Incremental Updates**: Efficient indexing with `--continue` flag
 - 🔒 **Privacy-First**: Local inference with MLX models - no API calls required
 - 🚀 **Apple Silicon Optimized**: Leverages MLX framework for fast local AI
+- 🖧 **MCP Server**: Expose add/search via JSON-RPC for MCP clients
 
 ## Prerequisites
 
@@ -171,6 +172,21 @@ Weekend plans for the family
 - Local models provide privacy and work offline
 - MLX models are optimized for Apple Silicon performance
 - The system supports both local and cloud models via configuration
+## MCP Server Setup
+
+This repository also includes `memories-mcp.sh`, a JSON-RPC server implementing the [MCP protocol](https://github.com/mcp-protocol/spec). It exposes `add` and `search` tools so editors can interact with your notes. Start the server from the repo directory:
+```bash
+./memories-mcp.sh
+```
+Logs are written to `/tmp/memories-mcp-requests.log`.
+
+### Client Setup
+- **Claude Desktop**: Add a custom MCP server and point it to the `memories-mcp.sh` script.
+- **Claude Code**: Use the MCP settings to register `./memories-mcp.sh` as a server.
+- **Zed**: In Preferences → AI, enable a custom MCP server and specify the script path.
+- **Cursor**: Configure the MCP command to run `memories-mcp.sh`.
+- **GitHub Co-Pilot**: Enable the experimental MCP endpoint and set it to `./memories-mcp.sh`.
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- document that the repo also works as an MCP server
- explain how to start `memories-mcp.sh`
- add setup instructions for Claude Desktop, Claude Code, Zed, Cursor and GitHub Copilot

## Testing
- `shellcheck add-note.sh index-notes.sh search-notes.sh memories-mcp.sh common.sh`

------
https://chatgpt.com/codex/tasks/task_b_68511a7225248333a01d84413798a1d8