### PR TITLE
Add self-updating vibe-coded badge

### DIFF
--- a/.github/workflows/update-vibe-badge.yml
+++ b/.github/workflows/update-vibe-badge.yml
@@ -1,0 +1,25 @@
+name: Update Vibe Badge
+
+on:
+  push:
+    branches: ["**"]
+
+jobs:
+  update:
+    if: "!contains(github.event.head_commit.message, '[skip vibe-badge]')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Update badge
+        run: |
+          bash scripts/update-vibe-badge.sh
+      - name: Push changes
+        run: |
+          if [ -f /tmp/badge_changed ]; then
+            git push
+          else
+            echo "No changes to push"
+          fi

--- a/scripts/update-vibe-badge.sh
+++ b/scripts/update-vibe-badge.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+TOTAL=$(git rev-list --count HEAD)
+VIBE=0
+for COMMIT in $(git rev-list HEAD); do
+  AUTHOR="$(git show -s --format='%an <%ae>' "$COMMIT")"
+  BODY="$(git show -s --format='%B' "$COMMIT")"
+  if echo "$AUTHOR" | grep -iE 'claude|codex|cursor|zed|windsurf|openai' >/dev/null \
+     || echo "$BODY" | grep -iE '🤖|generated with|co-?authored-?by:.*(claude|codex|cursor|zed|windsurf|openai)|signed-off-by:.*(claude|codex|cursor|zed|windsurf|openai)' >/dev/null; then
+    VIBE=$((VIBE + 1))
+  fi
+done
+
+if [ "$TOTAL" -eq 0 ]; then
+  PERCENT=0
+else
+  PERCENT=$((100 * VIBE / TOTAL))
+fi
+
+NEW_BADGE="[![${PERCENT}% Vibe Coded](https://img.shields.io/badge/${PERCENT}%25-Vibe_Coded-ff69b4?style=for-the-badge&logo=headphones&logoColor=white)](https://github.com/trieloff/apple-notes-semantic-search)"
+ESC_BADGE=$(printf '%s\n' "$NEW_BADGE" | sed 's/[#&]/\\&/g')
+
+perl -0pi -e "s#\[!\[\d+% Vibe Coded\]\(https://img.shields.io/badge/\d+%25-Vibe_Coded-ff69b4\?style=for-the-badge&logo=headphones&logoColor=white\)\]\(https://github.com/trieloff/apple-notes-semantic-search\)#$ESC_BADGE#" README.md
+
+if ! git diff --quiet README.md; then
+  git config user.name 'github-actions[bot]'
+  git config user.email 'github-actions[bot]@users.noreply.github.com'
+  git add README.md
+  git commit -m "Update vibe-coded badge to ${PERCENT}% [skip vibe-badge]"
+  touch /tmp/badge_changed
+fi


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that analyzes commit history
- compute percentage of vibe-coded commits and update the badge in README
- skip the workflow when it commits the badge to avoid loops
- implement script to calculate vibe percentage and push updates

## Testing
- `bash scripts/update-vibe-badge.sh`
- `bash -n scripts/update-vibe-badge.sh`
- `shellcheck scripts/update-vibe-badge.sh`

------
https://chatgpt.com/codex/tasks/task_b_68511b96dc5083338185179db3a46eeb