### PR TITLE
Fix permission for vibe badge workflow

### DIFF
--- a/.github/workflows/update-vibe-badge.yml
+++ b/.github/workflows/update-vibe-badge.yml
@@ -1,0 +1,28 @@
+name: Update Vibe Badge
+
+on:
+  push:
+    branches: ["**"]
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    if: "!contains(github.event.head_commit.message, '[skip vibe-badge]')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Update badge
+        run: |
+          bash scripts/update-vibe-badge.sh
+      - name: Push changes
+        run: |
+          if [ -f /tmp/badge_changed ]; then
+            git push
+          else
+            echo "No changes to push"
+          fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apple Notes Semantic Search
 
-[![100% Vibe Coded](https://img.shields.io/badge/100%25-Vibe_Coded-ff69b4?style=for-the-badge&logo=headphones&logoColor=white)](https://github.com/trieloff/apple-notes-semantic-search)
+[![90% Vibe Coded](https://img.shields.io/badge/90%25-Vibe_Coded-ff69b4?style=for-the-badge&logo=headphones&logoColor=white)](https://github.com/trieloff/apple-notes-semantic-search)
 
 A collection of shell scripts that add semantic search capabilities to Apple Notes using local AI models and embeddings for privacy-focused note management.
 

--- a/scripts/update-vibe-badge.sh
+++ b/scripts/update-vibe-badge.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+TOTAL=$(git rev-list --count HEAD)
+VIBE=0
+for COMMIT in $(git rev-list HEAD); do
+  AUTHOR="$(git show -s --format='%an <%ae>' "$COMMIT")"
+  BODY="$(git show -s --format='%B' "$COMMIT")"
+  if echo "$AUTHOR" | grep -iE 'claude|codex|cursor|zed|windsurf|openai' >/dev/null \
+     || echo "$BODY" | grep -iE '🤖|generated with|co-?authored-?by:.*(claude|codex|cursor|zed|windsurf|openai)|signed-off-by:.*(claude|codex|cursor|zed|windsurf|openai)' >/dev/null; then
+    VIBE=$((VIBE + 1))
+  fi
+done
+
+if [ "$TOTAL" -eq 0 ]; then
+  PERCENT=0
+else
+  PERCENT=$((100 * VIBE / TOTAL))
+fi
+
+NEW_BADGE="[![${PERCENT}% Vibe Coded](https://img.shields.io/badge/${PERCENT}%25-Vibe_Coded-ff69b4?style=for-the-badge&logo=headphones&logoColor=white)](https://github.com/trieloff/apple-notes-semantic-search)"
+ESC_BADGE=$(printf '%s\n' "$NEW_BADGE" | sed 's/[#&]/\\&/g')
+
+perl -0pi -e "s#\[!\[\d+% Vibe Coded\]\(https://img.shields.io/badge/\d+%25-Vibe_Coded-ff69b4\?style=for-the-badge&logo=headphones&logoColor=white\)\]\(https://github.com/trieloff/apple-notes-semantic-search\)#$ESC_BADGE#" README.md
+
+if ! git diff --quiet README.md; then
+  git config user.name 'github-actions[bot]'
+  git config user.email 'github-actions[bot]@users.noreply.github.com'
+  git add README.md
+  git commit -m "Update vibe-coded badge to ${PERCENT}% [skip vibe-badge]"
+  touch /tmp/badge_changed
+fi


### PR DESCRIPTION
## Summary
- grant write permissions so the vibe badge workflow can push updates

## Testing
- `bash scripts/update-vibe-badge.sh`
- `bash -n scripts/update-vibe-badge.sh`
- `shellcheck scripts/update-vibe-badge.sh`


------
https://chatgpt.com/codex/tasks/task_b_68511b96dc5083338185179db3a46eeb